### PR TITLE
Fix types not being exported correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "./lib/react-powerglitch.es.js",
   "exports": {
     ".": {
+      "types": "./types/lib/index.d.ts",
       "import": "./lib/react-powerglitch.es.js",
       "require": "./lib/react-powerglitch.umd.js"
     }


### PR DESCRIPTION
I get this error otherwise.

```
#12 11.72 Type error: Could not find a declaration file for module 'react-powerglitch'. '/app/node_modules/react-powerglitch/lib/react-powerglitch.es.js' implicitly has an 'any' type.
#12 11.72   There are types at '/app/node_modules/react-powerglitch/types/lib/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'react-powerglitch' library may need to update its package.json or typings.
```